### PR TITLE
Reducing the temp sensor cache expiry time.

### DIFF
--- a/Glovebox.Netduino/Sensors/SensorTemp.cs
+++ b/Glovebox.Netduino/Sensors/SensorTemp.cs
@@ -10,7 +10,7 @@ using Glovebox.Netduino.Drivers;
 
 namespace Glovebox.Netduino.Sensors {
     public class SensorTemp : SensorBase {
-        const uint temperatureCacheSeconds = 60 * 10;
+        const uint temperatureCacheSeconds = 10;
 
         DS18B20 ds = null;
         DateTime nextTemperatureReading = DateTime.MinValue;


### PR DESCRIPTION
Reducing the temp sensor cache expiry time so that it updates ever 10 seconds instead of every 10 minutes.

When doing lab 3 and checking the sensor output, I tried to get the sensor temp to fluctuate by warming with my finger. When the value didn't change, I thought that maybe my sensor was broken, so I started troubleshooting and noticed the temperatureCacheSeconds value. Should this be set to 10 minutes?

Thanks,
Neil
